### PR TITLE
Add latest manga endpoint and screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Le backend utilise la variable `JWT_SECRET` pour signer les tokens. Vous pouvez 
 - `POST /api/auth/login` – connexion et récupération d'un token JWT
 - `GET /api/manga/search?q=titre` – rechercher des mangas via Mangadex
 - `GET /api/manga/chapter/:id` – récupérer les pages d'un chapitre
+- `GET /api/manga/latest` – dernières sorties depuis Mangadex
 - `POST /api/watchlist` – ajouter un manga à sa liste (token requis)
 - `GET /api/watchlist` – lister les mangas suivis
 - `POST /api/watchlist/progress` – marquer un chapitre comme lu

--- a/back/routes/manga.js
+++ b/back/routes/manga.js
@@ -28,4 +28,16 @@ router.get('/chapter/:id', async (req, res) => {
   }
 });
 
+// Get latest chapters from Mangadex
+router.get('/latest', async (req, res) => {
+  try {
+    const resp = await axios.get('https://api.mangadex.org/chapter', {
+      params: { limit: 20, 'order[readableAt]': 'desc' },
+    });
+    res.json(resp.data);
+  } catch {
+    res.status(500).json({ message: 'Failed to fetch latest chapters' });
+  }
+});
+
 module.exports = router;

--- a/front/app/(tabs)/_layout.tsx
+++ b/front/app/(tabs)/_layout.tsx
@@ -34,6 +34,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="latest"
+        options={{
+          title: 'Nouveautés',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="clock.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="watchlist"
         options={{
           title: 'Mes mangas',

--- a/front/app/(tabs)/latest.tsx
+++ b/front/app/(tabs)/latest.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import axios from 'axios';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
+
+export default function LatestScreen() {
+  const [chapters, setChapters] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    try {
+      const { data } = await axios.get(`${API_URL}/api/manga/latest`);
+      setChapters(data.data || []);
+    } catch {
+      setChapters([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {loading ? (
+        <Text>Chargement...</Text>
+      ) : (
+        <FlatList
+          data={chapters}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View style={styles.item}>
+              <Text>
+                {item.attributes?.chapter
+                  ? `Chapitre ${item.attributes.chapter}`
+                  : 'Chapitre'}
+              </Text>
+              {item.attributes?.title ? (
+                <Text>{item.attributes.title}</Text>
+              ) : null}
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  item: {
+    paddingVertical: 8,
+  },
+});

--- a/front/components/ui/IconSymbol.tsx
+++ b/front/components/ui/IconSymbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'clock.fill': 'schedule',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- create `/api/manga/latest` route to fetch newest chapters from Mangadex
- document the new endpoint in README
- expose latest releases in frontend with a new tab
- add icon mapping for the new tab

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c7eb47f8832c95cd4d0587f7e2a5