### PR TITLE
Add Comick latest API and tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Le backend utilise la variable `JWT_SECRET` pour signer les tokens. Vous pouvez 
 - `POST /api/auth/login` – connexion et récupération d'un token JWT
 - `GET /api/manga/search?q=titre` – rechercher des mangas via Mangadex
 - `GET /api/manga/chapter/:id` – récupérer les pages d'un chapitre
+- `GET /api/comick/latest` – derniers chapitres via Comick
 - `POST /api/watchlist` – ajouter un manga à sa liste (token requis)
 - `GET /api/watchlist` – lister les mangas suivis
 - `POST /api/watchlist/progress` – marquer un chapitre comme lu

--- a/back/routes/comick.js
+++ b/back/routes/comick.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const axios = require('axios');
+const router = express.Router();
+
+// Get latest chapters from Comick
+router.get('/latest', async (req, res) => {
+  try {
+    const resp = await axios.get('https://comick.io/api/latest', {
+      params: { limit: 20 },
+    });
+    res.json(resp.data);
+  } catch (err) {
+    res.status(500).json({ message: 'Comick request failed' });
+  }
+});
+
+module.exports = router;

--- a/back/server.js
+++ b/back/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const dotenv = require('dotenv');
 const authRoutes = require('./routes/auth');
 const mangaRoutes = require('./routes/manga');
+const comickRoutes = require('./routes/comick');
 const watchlistRoutes = require('./routes/watchlist');
 
 // Configuration des variables d'environnement
@@ -17,6 +18,7 @@ app.use(express.json());
 // API routes
 app.use('/api/auth', authRoutes);
 app.use('/api/manga', mangaRoutes);
+app.use('/api/comick', comickRoutes);
 app.use('/api/watchlist', watchlistRoutes);
 
 // Routes de base

--- a/front/app/(tabs)/_layout.tsx
+++ b/front/app/(tabs)/_layout.tsx
@@ -34,6 +34,15 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="latest"
+        options={{
+          title: 'Derniers',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="clock.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="watchlist"
         options={{
           title: 'Mes mangas',

--- a/front/app/(tabs)/latest.tsx
+++ b/front/app/(tabs)/latest.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, View, FlatList, Text } from 'react-native';
+import axios from 'axios';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
+
+export default function LatestScreen() {
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const { data } = await axios.get(`${API_URL}/api/comick/latest`);
+      const list = Array.isArray(data) ? data : data?.data || [];
+      setItems(list);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {loading ? (
+        <Text>Chargement...</Text>
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(item, idx) => item.id?.toString() || idx.toString()}
+          renderItem={({ item }) => (
+            <View style={styles.item}>
+              <Text>{item.title || item.slug || 'Sans titre'}</Text>
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  item: {
+    paddingVertical: 8,
+  },
+});

--- a/front/components/ui/IconSymbol.tsx
+++ b/front/components/ui/IconSymbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'clock.fill': 'schedule',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- expose `/api/comick/latest` endpoint from backend
- list the new route in README
- show latest chapters in a new "Derniers" tab in the app
- map a new clock icon

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9a7ffac832cb476afeac92fb977