### PR TITLE
Fix reader base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ npx expo start
 
 Expo vous proposera ensuite d'ouvrir l'application sur un appareil ou un émulateur.
 
+> **Astuce** : si vous testez l'application sur un appareil physique, pensez à
+> définir la variable d'environnement `EXPO_PUBLIC_API_URL` afin que le front-end
+> puisse contacter votre serveur local. Par exemple :
+>
+> ```bash
+> EXPO_PUBLIC_API_URL="http://192.168.1.10:3000" npx expo start
+> ```
+>
+> Remplacez l'adresse IP par celle de votre machine hébergeant le backend.
+
 ## Structure du dépôt
 
 - `back/` – Serveur Express

--- a/front/utils/api.ts
+++ b/front/utils/api.ts
@@ -1,7 +1,19 @@
 import axios from 'axios';
+import Constants from 'expo-constants';
 
-/** Base URL for backend API */
-export const API_URL = "http://localhost:3000";
+/**
+ * Determine the backend base URL.
+ *
+ * When running the Expo app on a physical device, "localhost" does not
+ * resolve to the development machine. We expose `EXPO_PUBLIC_API_URL` so the
+ * URL can be configured at runtime (e.g. via `--env`) and fall back to
+ * `Constants.expoConfig.extra.API_URL` if provided. If none is defined we use
+ * `http://localhost:3000` as a sensible default.
+ */
+export const API_URL =
+  process.env.EXPO_PUBLIC_API_URL ||
+  Constants.expoConfig?.extra?.API_URL ||
+  'http://localhost:3000';
 
 /** Preconfigured axios instance for the backend API */
 export const api = axios.create({


### PR DESCRIPTION
## Summary
- allow custom API base URL so images load on device
- document EXPO_PUBLIC_API_URL usage

## Testing
- `npm run lint` *(fails: expo lint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68810bcc0f4c832c96dc529afc8789d2